### PR TITLE
feat: 라우팅 페이지 설정

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -29,7 +29,7 @@ export const BottomNavigation = () => {
         d={visible ? undefined : "none"}
       >
         <TabList>
-          <Tab as={Link} to="schedule">
+          <Tab as={Link} to="schedules">
             <Icon as={IoTodaySharp} w={8} h={8} />
           </Tab>
           <Tab as={Link} to="posts">

--- a/src/components/BottomNavigation/useBottomNavigation.ts
+++ b/src/components/BottomNavigation/useBottomNavigation.ts
@@ -2,7 +2,7 @@ import { useBoolean } from "@chakra-ui/hooks";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useLocation } from "react-router-dom";
 
-const allowedPathNames = ["schedule", "posts", "profile"];
+const allowedPathNames = ["schedules", "posts", "profile"];
 
 export const useBottomNavigation = () => {
   const [visible, setVisible] = useBoolean(false);

--- a/src/features/posts/components/Post/Post.tsx
+++ b/src/features/posts/components/Post/Post.tsx
@@ -9,6 +9,7 @@ import {
   Flex,
 } from "@chakra-ui/react";
 import { IoLocationSharp, IoCalendarSharp } from "react-icons/io5";
+import { Link } from "react-router-dom";
 
 import { TextWithIcon } from "@/components/TextWithIcon";
 
@@ -30,7 +31,9 @@ export const Post = () => {
         <Box>테마</Box>
       </HStack>
       <Heading size="md" my={4}>
-        <LinkOverlay href="#">제목</LinkOverlay>
+        <LinkOverlay as={Link} to="id">
+          제목
+        </LinkOverlay>
       </Heading>
       <Flex justify="space-between">
         <TextWithIcon icon={<IoLocationSharp />}>도시명</TextWithIcon>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,15 @@
+import { Center } from "@chakra-ui/react";
+
+import { PublicPageLayout } from "@/components/Layout";
+import { Logo } from "@/components/Logo";
+
+export const LoginPage = () => {
+  return (
+    <PublicPageLayout title="로그인">
+      <Center>
+        <Logo />
+      </Center>
+      로그인 페이지
+    </PublicPageLayout>
+  );
+};

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,0 +1,15 @@
+import { Center } from "@chakra-ui/react";
+
+import { PublicPageLayout } from "@/components/Layout";
+import { Logo } from "@/components/Logo";
+
+export const RegisterPage = () => {
+  return (
+    <PublicPageLayout title="회원가입">
+      <Center>
+        <Logo />
+      </Center>
+      회원가입 페이지
+    </PublicPageLayout>
+  );
+};

--- a/src/pages/auth/index.ts
+++ b/src/pages/auth/index.ts
@@ -1,1 +1,3 @@
 export * from "./LandingPage";
+export * from "./LoginPage";
+export * from "./RegisterPage";

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,4 +2,5 @@ export * from "./posts";
 export * from "./profile";
 export * from "./schedules";
 export * from "./vote";
+export * from "./memo";
 export * from "./note";

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,3 +2,4 @@ export * from "./posts";
 export * from "./profile";
 export * from "./schedules";
 export * from "./vote";
+export * from "./note";

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,3 +1,4 @@
 export * from "./posts";
 export * from "./profile";
 export * from "./schedules";
+export * from "./vote";

--- a/src/pages/memo/MemoPage.tsx
+++ b/src/pages/memo/MemoPage.tsx
@@ -1,0 +1,17 @@
+import { Heading } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const MemoPage = () => {
+  const { memoId } = useParams();
+
+  return (
+    <PrivatePageLayout
+      title="메모 및 투표"
+      header={<Heading size="lg">메모 및 투표</Heading>}
+    >
+      메모 상세 보기
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/memo/MemoUpdatePage.tsx
+++ b/src/pages/memo/MemoUpdatePage.tsx
@@ -1,0 +1,17 @@
+import { Heading } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const MemoUpdatePage = () => {
+  const { memoId } = useParams();
+
+  return (
+    <PrivatePageLayout
+      title="id"
+      header={<Heading size="lg">메모 {memoId ? "수정" : "생성"}</Heading>}
+    >
+      메모 갱신
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/memo/index.ts
+++ b/src/pages/memo/index.ts
@@ -1,0 +1,2 @@
+export * from "./MemoPage";
+export * from "./MemoUpdatePage";

--- a/src/pages/note/NotePage.tsx
+++ b/src/pages/note/NotePage.tsx
@@ -1,0 +1,14 @@
+import { Heading } from "@chakra-ui/react";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const NotePage = () => {
+  return (
+    <PrivatePageLayout
+      title="메모 및 투표"
+      header={<Heading size="lg">메모 및 투표</Heading>}
+    >
+      메모, 투표 리스트
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/note/index.ts
+++ b/src/pages/note/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotePage";

--- a/src/pages/posts/PostPage.tsx
+++ b/src/pages/posts/PostPage.tsx
@@ -1,0 +1,14 @@
+import { Heading } from "@chakra-ui/react";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const PostPage = () => {
+  return (
+    <PrivatePageLayout
+      title="id"
+      header={<Heading size="lg">플랜보기</Heading>}
+    >
+      포스트 보기
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/posts/PostUpdatePage.tsx
+++ b/src/pages/posts/PostUpdatePage.tsx
@@ -1,0 +1,17 @@
+import { Heading } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const PostUpdatePage = () => {
+  const { postId } = useParams();
+
+  return (
+    <PrivatePageLayout
+      title="id"
+      header={<Heading size="lg">포스트 {postId ? "수정" : "생성"}</Heading>}
+    >
+      포스트 갱신
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/posts/PostsPage.tsx
+++ b/src/pages/posts/PostsPage.tsx
@@ -18,7 +18,7 @@ export const PostsPage = () => {
       </Box>
       <Flex justify="flex-end" my={4}>
         <HStack flexShrink={0}>
-          <SortBySelect variant="unstyled" />
+          <SortBySelect />
         </HStack>
       </Flex>
       <Box my={4}>

--- a/src/pages/posts/index.ts
+++ b/src/pages/posts/index.ts
@@ -1,2 +1,3 @@
 export * from "./PostsPage";
 export * from "./PostPage";
+export * from "./PostUpdatePage";

--- a/src/pages/posts/index.ts
+++ b/src/pages/posts/index.ts
@@ -1,1 +1,2 @@
 export * from "./PostsPage";
+export * from "./PostPage";

--- a/src/pages/schedules/SchedulePage.tsx
+++ b/src/pages/schedules/SchedulePage.tsx
@@ -1,0 +1,14 @@
+import { Heading } from "@chakra-ui/react";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const SchedulePage = () => {
+  return (
+    <PrivatePageLayout
+      title="id"
+      header={<Heading size="lg">스케줄 보기</Heading>}
+    >
+      스케줄 보기
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/schedules/ScheduleUpdatePage.tsx
+++ b/src/pages/schedules/ScheduleUpdatePage.tsx
@@ -1,0 +1,19 @@
+import { Heading } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const ScheduleUpdatePage = () => {
+  const { scheduleId } = useParams();
+
+  return (
+    <PrivatePageLayout
+      title="id"
+      header={
+        <Heading size="lg">스케줄 {scheduleId ? "수정" : "생성"}</Heading>
+      }
+    >
+      스케줄 갱신
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/schedules/SchedulesPage.tsx
+++ b/src/pages/schedules/SchedulesPage.tsx
@@ -1,4 +1,5 @@
-import { Heading } from "@chakra-ui/react";
+import { Heading, Button } from "@chakra-ui/react";
+import { Link } from "react-router-dom";
 
 import { PrivatePageLayout } from "@/components/Layout";
 
@@ -8,7 +9,9 @@ export const SchedulesPage = () => {
       title="나의 트립플랜"
       header={<Heading size="lg">나의 트립플랜</Heading>}
     >
-      Schedule
+      <Button as={Link} to="id">
+        스케줄 보기
+      </Button>
     </PrivatePageLayout>
   );
 };

--- a/src/pages/schedules/index.ts
+++ b/src/pages/schedules/index.ts
@@ -1,2 +1,3 @@
 export * from "./SchedulesPage";
 export * from "./SchedulePage";
+export * from "./ScheduleUpdatePage";

--- a/src/pages/schedules/index.ts
+++ b/src/pages/schedules/index.ts
@@ -1,1 +1,2 @@
 export * from "./SchedulesPage";
+export * from "./SchedulePage";

--- a/src/pages/vote/VotePage.tsx
+++ b/src/pages/vote/VotePage.tsx
@@ -1,0 +1,17 @@
+import { Heading } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const VotePage = () => {
+  const { voteId } = useParams();
+
+  return (
+    <PrivatePageLayout
+      title="메모 및 투표"
+      header={<Heading size="lg">메모 및 투표</Heading>}
+    >
+      투표 상세 보기
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/vote/VoteUpdatePage.tsx
+++ b/src/pages/vote/VoteUpdatePage.tsx
@@ -1,0 +1,17 @@
+import { Heading } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+
+import { PrivatePageLayout } from "@/components/Layout";
+
+export const VoteUpdatePage = () => {
+  const { voteId } = useParams();
+
+  return (
+    <PrivatePageLayout
+      title="id"
+      header={<Heading size="lg">투표 {voteId ? "수정" : "생성"}</Heading>}
+    >
+      투표 갱신
+    </PrivatePageLayout>
+  );
+};

--- a/src/pages/vote/index.ts
+++ b/src/pages/vote/index.ts
@@ -1,0 +1,2 @@
+export * from "./VotePage";
+export * from "./VoteUpdatePage";

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,6 +23,8 @@ const { SchedulesRoutes } = lazyImport(
 
 const { VoteRoutes } = lazyImport(() => import("@/routes/vote"), "VoteRoutes");
 
+const { NoteRoutes } = lazyImport(() => import("@/routes/note"), "NoteRoutes");
+
 const { LandingPage } = lazyImport(() => import("@/pages/auth"), "LandingPage");
 
 const { LoginPage } = lazyImport(() => import("@/pages/auth"), "LoginPage");
@@ -58,6 +60,7 @@ export const AppRoutes = () => {
         <Route path="profile" element={<ProfilePage />} />
         <Route path="posts/*" element={<PostsRoutes />} />
         <Route path="schedules/*" element={<SchedulesRoutes />} />
+        <Route path="note/*" element={<NoteRoutes />} />
         <Route path="vote/*" element={<VoteRoutes />} />
         <Route path="*" element={<Navigate to="." />} />
       </Route>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,12 @@ const { ProfilePage } = lazyImport(
   () => import("@/pages/profile"),
   "ProfilePage"
 );
+
+const { PostsRoutes } = lazyImport(
+  () => import("@/routes/posts"),
+  "PostsRoutes"
+);
+
 const { SchedulesPage } = lazyImport(
   () => import("@/pages/schedules"),
   "SchedulesPage"
@@ -29,7 +35,7 @@ const App = () => {
     <AppLayout>
       <Suspense
         fallback={
-          <Center w="100%" h="100vh">
+          <Center h="100vh">
             <Spinner />
           </Center>
         }
@@ -48,6 +54,7 @@ export const AppRoutes = () => {
         <Route path="login" element={<LoginPage />} />
         <Route path="register" element={<RegisterPage />} />
         <Route path="profile" element={<ProfilePage />} />
+        <Route path="posts/*" element={<PostsRoutes />} />
         <Route path="schedule" element={<SchedulesPage />} />
         <Route path="*" element={<Navigate to="." />} />
       </Route>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,6 +23,7 @@ const { SchedulesRoutes } = lazyImport(
 
 const { VoteRoutes } = lazyImport(() => import("@/routes/vote"), "VoteRoutes");
 
+const { MemoRoutes } = lazyImport(() => import("@/routes/memo"), "MemoRoutes");
 const { NoteRoutes } = lazyImport(() => import("@/routes/note"), "NoteRoutes");
 
 const { LandingPage } = lazyImport(() => import("@/pages/auth"), "LandingPage");
@@ -62,6 +63,7 @@ export const AppRoutes = () => {
         <Route path="schedules/*" element={<SchedulesRoutes />} />
         <Route path="note/*" element={<NoteRoutes />} />
         <Route path="vote/*" element={<VoteRoutes />} />
+        <Route path="memo/*" element={<MemoRoutes />} />
         <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,10 @@
 import { Spinner, Center } from "@chakra-ui/react";
 import { Suspense } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, Navigate } from "react-router-dom";
 import { Routes, Route } from "react-router-dom";
 
 import { AppLayout } from "@/components/Layout";
 import { lazyImport } from "@/utils/lazyImport";
-
-const { PostsPage } = lazyImport(() => import("@/pages/posts"), "PostsPage");
 
 const { ProfilePage } = lazyImport(
   () => import("@/pages/profile"),
@@ -18,6 +16,13 @@ const { SchedulesPage } = lazyImport(
 );
 
 const { LandingPage } = lazyImport(() => import("@/pages/auth"), "LandingPage");
+
+const { LoginPage } = lazyImport(() => import("@/pages/auth"), "LoginPage");
+
+const { RegisterPage } = lazyImport(
+  () => import("@/pages/auth"),
+  "RegisterPage"
+);
 
 const App = () => {
   return (
@@ -40,9 +45,11 @@ export const AppRoutes = () => {
     <Routes>
       <Route path="/" element={<App />}>
         <Route index element={<LandingPage />} />
-        <Route path="posts" element={<PostsPage />} />
+        <Route path="login" element={<LoginPage />} />
+        <Route path="register" element={<RegisterPage />} />
         <Route path="profile" element={<ProfilePage />} />
         <Route path="schedule" element={<SchedulesPage />} />
+        <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>
   );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,6 +21,8 @@ const { SchedulesRoutes } = lazyImport(
   "SchedulesRoutes"
 );
 
+const { VoteRoutes } = lazyImport(() => import("@/routes/vote"), "VoteRoutes");
+
 const { LandingPage } = lazyImport(() => import("@/pages/auth"), "LandingPage");
 
 const { LoginPage } = lazyImport(() => import("@/pages/auth"), "LoginPage");
@@ -56,6 +58,7 @@ export const AppRoutes = () => {
         <Route path="profile" element={<ProfilePage />} />
         <Route path="posts/*" element={<PostsRoutes />} />
         <Route path="schedules/*" element={<SchedulesRoutes />} />
+        <Route path="vote/*" element={<VoteRoutes />} />
         <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -16,9 +16,9 @@ const { PostsRoutes } = lazyImport(
   "PostsRoutes"
 );
 
-const { SchedulesPage } = lazyImport(
-  () => import("@/pages/schedules"),
-  "SchedulesPage"
+const { SchedulesRoutes } = lazyImport(
+  () => import("@/routes/schedules"),
+  "SchedulesRoutes"
 );
 
 const { LandingPage } = lazyImport(() => import("@/pages/auth"), "LandingPage");
@@ -55,7 +55,7 @@ export const AppRoutes = () => {
         <Route path="register" element={<RegisterPage />} />
         <Route path="profile" element={<ProfilePage />} />
         <Route path="posts/*" element={<PostsRoutes />} />
-        <Route path="schedule" element={<SchedulesPage />} />
+        <Route path="schedules/*" element={<SchedulesRoutes />} />
         <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>

--- a/src/routes/memo/index.tsx
+++ b/src/routes/memo/index.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import { MemoPage, MemoUpdatePage } from "@/pages";
+
+export const MemoRoutes = () => {
+  return (
+    <Routes>
+      <Route index element={<Navigate to="/" />} />
+      <Route path=":memoId" element={<MemoPage />} />
+      <Route path="update" element={<MemoUpdatePage />} />
+      <Route path="update/:voteId" element={<MemoUpdatePage />} />
+      <Route path="*" element={<Navigate to="." />} />
+    </Routes>
+  );
+};

--- a/src/routes/note/index.tsx
+++ b/src/routes/note/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import { NotePage } from "@/pages";
+
+export const NoteRoutes = () => {
+  return (
+    <Routes>
+      <Route index element={<NotePage />} />
+      <Route path="*" element={<Navigate to="." />} />
+    </Routes>
+  );
+};

--- a/src/routes/posts/index.tsx
+++ b/src/routes/posts/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import { PostsPage, PostPage } from "@/pages";
+
+export const PostsRoutes = () => {
+  return (
+    <Routes>
+      <Route index element={<PostsPage />} />
+      <Route path=":postId" element={<PostPage />} />
+      <Route path="*" element={<Navigate to="." />} />
+    </Routes>
+  );
+};

--- a/src/routes/posts/index.tsx
+++ b/src/routes/posts/index.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
-import { PostsPage, PostPage } from "@/pages";
+import { PostsPage, PostPage, PostUpdatePage } from "@/pages";
 
 export const PostsRoutes = () => {
   return (
     <Routes>
       <Route index element={<PostsPage />} />
       <Route path=":postId" element={<PostPage />} />
+      <Route path="update" element={<PostUpdatePage />} />
+      <Route path="update/:postId" element={<PostUpdatePage />} />
       <Route path="*" element={<Navigate to="." />} />
     </Routes>
   );

--- a/src/routes/schedules/index.tsx
+++ b/src/routes/schedules/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import { SchedulesPage, SchedulePage } from "@/pages";
+
+export const SchedulesRoutes = () => {
+  return (
+    <Routes>
+      <Route index element={<SchedulesPage />} />
+      <Route path=":scheduleId" element={<SchedulePage />} />
+      <Route path="*" element={<Navigate to="." />} />
+    </Routes>
+  );
+};

--- a/src/routes/schedules/index.tsx
+++ b/src/routes/schedules/index.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
-import { SchedulesPage, SchedulePage } from "@/pages";
+import { SchedulesPage, SchedulePage, ScheduleUpdatePage } from "@/pages";
 
 export const SchedulesRoutes = () => {
   return (
     <Routes>
       <Route index element={<SchedulesPage />} />
       <Route path=":scheduleId" element={<SchedulePage />} />
+      <Route path="update" element={<ScheduleUpdatePage />} />
+      <Route path="update/:scheduleId" element={<ScheduleUpdatePage />} />
       <Route path="*" element={<Navigate to="." />} />
     </Routes>
   );

--- a/src/routes/vote/index.tsx
+++ b/src/routes/vote/index.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import { VotePage, VoteUpdatePage } from "@/pages";
+
+export const VoteRoutes = () => {
+  return (
+    <Routes>
+      <Route index element={<Navigate to="/" />} />
+      <Route path=":voteId" element={<VotePage />} />
+      <Route path="update" element={<VoteUpdatePage />} />
+      <Route path="update/:voteId" element={<VoteUpdatePage />} />
+      <Route path="*" element={<Navigate to="." />} />
+    </Routes>
+  );
+};


### PR DESCRIPTION
## 🧑‍💻 PR 내용

- `/` -> 랜딩 페이지
- `/login` -> 로그인 페이지
- `/register` -> 회원가입 페이지
- `/posts` -> 게시글 리스트 페이지
- `/posts/:postId` -> 게시글 상세 조회 페이지
- `/posts/update` -> 게시글 생성 페이지
- `/posts/update/:postId` -> 게시글 수정 페이지
- `/schedules` -> 나의 일정 리스트 페이지
- `/schedules/:scheduleId` -> 일정 상세 조회 페이지
- `/schedules/update` -> 일정 생성 페이지
- `/schedules/update/:scheduleId` -> 일정 수정 페이지
- `/note` -> 메모 및 투표 조회 페이지
- `/memo/:memoId` -> 메모 조회 페이지
- `/memo/update` -> 메모 생성 페이지
- `/memo/update/:memoId` -> 메모 수정 페이지
- `/vote/:voteId` -> 투표 조회 페이지
- `/vote/update` -> 투표 생성 페이지
- `/vote/update/:voteId` -> 투표 수정 페이지

- UI 상으로 생성, 수정이 페이지를 공유하여서 new와 같은 경로로 페이지를 분리하기 보다는 동일한 update라는 경로를 사용하는 형태로 구상해보았습니다.
- 대신 params로 id가 전달되지 않은 경우를 **생성**, id가 존재하는 경우를 **수정**으로 식별하여 분기하면 될 것 같습니다.

## 📸 스크린샷

- `/schedules/update/123`로 접근한 경우
![image](https://user-images.githubusercontent.com/37530109/145002305-4c91e180-ecbf-4ded-b7f2-7eb413e439bc.png)

- `schedules/update`로 접근한 경우
![image](https://user-images.githubusercontent.com/37530109/145002334-89f05273-8cab-4e8b-8e86-aeac0f9d8c65.png)

