### PR TITLE
feat: 로그인 페이지 및 회원가입 페이지 구현

### DIFF
--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -4,8 +4,8 @@ export const Logo = (props: HTMLChakraProps<"svg">) => {
   return (
     <chakra.svg
       aria-hidden
-      width="241px"
-      height="80px"
+      width="180px"
+      height="60px"
       viewBox="0 0 241 80"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -1,0 +1,40 @@
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  Button,
+  Text,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
+import React from "react";
+import { Link } from "react-router-dom";
+
+export const LoginForm = () => {
+  return (
+    <form>
+      <Stack spacing={4}>
+        <FormControl id="email">
+          <FormLabel>이메일</FormLabel>
+          <Input type="email" placeholder="이메일을 입력해주세요." />
+        </FormControl>
+        <FormControl id="password">
+          <FormLabel>비밀번호</FormLabel>
+          <Input type="password" placeholder="비밀번호를 입력해주세요." />
+        </FormControl>
+        <Box>
+          <Button type="submit" colorScheme="cyan" size="lg" isFullWidth my={4}>
+            로그인
+          </Button>
+        </Box>
+        <Box>
+          <Text fontSize="sm">아직 계정이 없으신가요?</Text>
+          <ChakraLink as={Link} to="/register" color={"cyan.600"}>
+            회원가입
+          </ChakraLink>
+        </Box>
+      </Stack>
+    </form>
+  );
+};

--- a/src/features/auth/components/LoginForm/index.ts
+++ b/src/features/auth/components/LoginForm/index.ts
@@ -1,0 +1,1 @@
+export * from "./LoginForm";

--- a/src/features/auth/components/RegisterForm/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm/RegisterForm.tsx
@@ -1,0 +1,72 @@
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  Button,
+  Text,
+  HStack,
+  Select,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
+import React from "react";
+import { Link } from "react-router-dom";
+
+export const RegisterForm = () => {
+  return (
+    <form>
+      <Stack spacing={4}>
+        <FormControl id="name">
+          <FormLabel>이름</FormLabel>
+          <Input type="text" placeholder="이름을 입력해주세요." />
+        </FormControl>
+        <HStack>
+          <Box flexGrow="1">
+            <FormControl id="gender">
+              <FormLabel>성별</FormLabel>
+              <Select>
+                <option value="option1">남성</option>
+                <option value="option2">여성</option>
+              </Select>
+            </FormControl>
+          </Box>
+          <Box flexGrow="1">
+            <FormControl id="birth-date">
+              <FormLabel>생년월일</FormLabel>
+              <Input type="date" />
+            </FormControl>
+          </Box>
+        </HStack>
+        <FormControl id="nickname">
+          <FormLabel>닉네임</FormLabel>
+          <Input type="text" placeholder="닉네임을 입력해주세요." />
+        </FormControl>
+        <FormControl id="email">
+          <FormLabel>이메일</FormLabel>
+          <Input type="email" placeholder="이메일을 입력해주세요." />
+        </FormControl>
+        <FormControl id="password">
+          <FormLabel>비밀번호</FormLabel>
+          <Input type="password" placeholder="비밀번호를 입력해주세요." />
+        </FormControl>
+        <FormControl id="password-confirm">
+          <FormLabel>비밀번호 확인</FormLabel>
+          <Input
+            type="password"
+            placeholder="비밀번호를 한번 더 입력해주세요."
+          />
+        </FormControl>
+        <Box>
+          <Text fontSize="sm">이미 계정이 있으신가요?</Text>
+          <ChakraLink as={Link} to="/login" color={"cyan.600"}>
+            로그인
+          </ChakraLink>
+        </Box>
+        <Button type="submit" colorScheme="cyan" size="lg" isFullWidth my={4}>
+          회원가입
+        </Button>
+      </Stack>
+    </form>
+  );
+};

--- a/src/features/auth/components/RegisterForm/index.ts
+++ b/src/features/auth/components/RegisterForm/index.ts
@@ -1,2 +1,1 @@
-export * from "./LoginForm";
 export * from "./RegisterForm";

--- a/src/features/auth/components/index.ts
+++ b/src/features/auth/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./LoginForm";

--- a/src/pages/auth/LandingPage.tsx
+++ b/src/pages/auth/LandingPage.tsx
@@ -12,7 +12,7 @@ export const LandingPage = () => {
           <Logo />
         </Center>
 
-        <Button as={Link} to="/login" isFullWidth size="lg">
+        <Button as={Link} to="/login" colorScheme="cyan" isFullWidth size="lg">
           시작하기
         </Button>
       </Flex>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,7 +1,8 @@
-import { Center } from "@chakra-ui/react";
+import { Box, Center } from "@chakra-ui/react";
 
 import { PublicPageLayout } from "@/components/Layout";
 import { Logo } from "@/components/Logo";
+import { LoginForm } from "@/features/auth/components";
 
 export const LoginPage = () => {
   return (
@@ -9,7 +10,9 @@ export const LoginPage = () => {
       <Center>
         <Logo />
       </Center>
-      로그인 페이지
+      <Box mt={4}>
+        <LoginForm />
+      </Box>
     </PublicPageLayout>
   );
 };

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,7 +1,8 @@
-import { Center } from "@chakra-ui/react";
+import { Center, Box } from "@chakra-ui/react";
 
 import { PublicPageLayout } from "@/components/Layout";
 import { Logo } from "@/components/Logo";
+import { RegisterForm } from "@/features/auth/components";
 
 export const RegisterPage = () => {
   return (
@@ -9,7 +10,9 @@ export const RegisterPage = () => {
       <Center>
         <Logo />
       </Center>
-      회원가입 페이지
+      <Box mt={4}>
+        <RegisterForm />
+      </Box>
     </PublicPageLayout>
   );
 };


### PR DESCRIPTION
## 🧑‍💻 PR 내용

- 로고의 크기가 너무 큰 것 같아 크기를 조정하였습니다.
- 회원가입 페이지에 대한 마크업도 함께 진행하였습니다.
- 현재 날짜를 선택할 수 있는 input은 [type="date"]를 사용한 상태로 마이페이지에 대한 마크업 종료 시 DatePicker라는 공통 컴포넌트를 구현할 계획입니다.

## 📸 스크린샷

로그인 페이지             |  회원가입 페이지
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/37530109/145042860-0307d68f-78ee-4f60-89cd-02a73aa79922.png)  | ![image](https://user-images.githubusercontent.com/37530109/145043305-ff9373ac-6e02-48cd-8bd0-9eb47f7be5d1.png)

