### PR TITLE
fix: LinkOverLay를 Link 컴포넌트로 변경

### DIFF
--- a/src/pages/note/NotePage.tsx
+++ b/src/pages/note/NotePage.tsx
@@ -1,6 +1,8 @@
 import { Heading } from "@chakra-ui/react";
+import React from "react";
 import { useLocation } from "react-router-dom";
 
+import { GoToBackButton } from "@/components/GoToBackButton";
 import { PrivatePageLayout } from "@/components/Layout";
 import { NoteTabs } from "@/features/note/components";
 
@@ -10,7 +12,12 @@ export const NotePage = () => {
   return (
     <PrivatePageLayout
       title="메모 및 투표"
-      header={<Heading size="lg">메모 및 투표</Heading>}
+      header={
+        <>
+          <GoToBackButton />
+          <Heading size="lg">메모 및 투표</Heading>
+        </>
+      }
     >
       <NoteTabs />
     </PrivatePageLayout>

--- a/src/pages/schedules/SchedulePage.tsx
+++ b/src/pages/schedules/SchedulePage.tsx
@@ -20,7 +20,7 @@ import {
   List,
   ListItem,
   VisuallyHidden,
-  LinkOverlay,
+  Link as ChakraLink,
 } from "@chakra-ui/react";
 import React from "react";
 import {
@@ -221,14 +221,14 @@ export const SchedulePage = () => {
           </Stack>
         </Box>
         <Flex justifyContent="flex-end">
-          <LinkOverlay as={Link} to={"/note"} state={scheduleId}>
+          <ChakraLink as={Link} to={"/note"} state={scheduleId}>
             <HStack>
               <Text fontSize="lg" color="gray.700">
                 메모 및 투표
               </Text>
               <IoChevronForward size="22" color="#2D3748" />
             </HStack>
-          </LinkOverlay>
+          </ChakraLink>
         </Flex>
       </Stack>
     </PrivatePageLayout>


### PR DESCRIPTION
## 🧑‍💻 PR 내용

전체가 하나의 `Stack`으로 감싸진 형태라 페이지 내 모든 클릭이 link로 연결되고 있네요 😭😭
`LinkOverLay 컴포넌트` => `Link as ChakraLink 컴포넌트`로 변경했습니다.

