### PR TITLE
feat: AddScheduleForm 상태 값 react-hook-form으로 교체

### DIFF
--- a/src/features/schedules/components/AddSchleduleForm/AddScheduleForm.tsx
+++ b/src/features/schedules/components/AddSchleduleForm/AddScheduleForm.tsx
@@ -18,7 +18,7 @@ import {
 } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { format, differenceInDays, isEqual } from "date-fns";
+import { format, differenceInDays, isEqual, addDays } from "date-fns";
 import { useState, ReactElement } from "react";
 import {
   SubmitHandler,
@@ -80,7 +80,20 @@ const schema = yup.object().shape({
   endDate: yup
     .date()
     .required()
-    .min(yup.ref("startDate"), "출발 날짜 이후여야 합니다."),
+    .min(yup.ref("startDate"), "출발 날짜 이후여야 합니다.")
+    .when(
+      "startDate",
+      (startDate, schema) =>
+        startDate &&
+        schema.max(
+          addDays(startDate, 6),
+          `완료날짜는 ${format(
+            addDays(startDate, 6),
+            "yyyy-MM-dd"
+          )}이전이여야 합니다`
+        )
+    ),
+
   dailySchedulePlaces: yup
     .array()
     .of(

--- a/src/features/schedules/components/Carousel/Carousel.tsx
+++ b/src/features/schedules/components/Carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import { useBreakpointValue } from "@chakra-ui/react";
-import { useKeenSlider } from "keen-slider/react";
+import { useKeenSlider, KeenSliderPlugin } from "keen-slider/react";
 import { Children, cloneElement, PropsWithChildren } from "react";
 import "keen-slider/keen-slider.min.css";
 
@@ -13,17 +13,36 @@ type CarouselProps = PropsWithChildren<{
   spacing?: number;
 }>;
 
+const MutationPlugin: KeenSliderPlugin = (slider) => {
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      slider.update();
+    });
+  });
+  const config = { childList: true };
+
+  slider.on("created", () => {
+    observer.observe(slider.container, config);
+  });
+  slider.on("destroyed", () => {
+    observer.disconnect();
+  });
+};
+
 export const Carousel = (props: CarouselProps) => {
   const { perViewInfo = { base: 1 }, spacing = 10, children } = props;
 
   const perView = useBreakpointValue(perViewInfo);
   const validChildren = getValidChildren(children);
-  const [sliderRef] = useKeenSlider<HTMLDivElement>({
-    slides: {
-      perView,
-      spacing,
+  const [sliderRef] = useKeenSlider<HTMLDivElement>(
+    {
+      slides: {
+        perView,
+        spacing,
+      },
     },
-  });
+    [MutationPlugin]
+  );
 
   return (
     <Box ref={sliderRef} className="keen-slider">

--- a/src/features/schedules/components/Daily/Daily.tsx
+++ b/src/features/schedules/components/Daily/Daily.tsx
@@ -10,7 +10,7 @@ import {
 import { IoClose } from "react-icons/io5";
 
 type DailyPlace = {
-  date: number;
+  dateIdx: number;
   placeName: string;
   spotId: string;
 };
@@ -37,7 +37,7 @@ export const Daily = (props: DailyProps) => {
       pb={8}
       borderRadius="md"
       onClick={() => {
-        onClick && onClick(idx);
+        onClick?.(idx);
       }}
       className={className}
     >
@@ -46,11 +46,11 @@ export const Daily = (props: DailyProps) => {
           day{idx + 1}
         </Heading>
         <Stack spacing={2}>
-          {dailyPlaces.map((dailyPlace, _idx, array) => {
-            if (dailyPlace.date === idx) {
+          {dailyPlaces.map((dailyPlace, dailyPlaceIdx) => {
+            if (dailyPlace.dateIdx === idx) {
               return (
                 <HStack
-                  key={`Daily-${_idx}-${dailyPlace.spotId}`}
+                  key={`Daily-${dailyPlaceIdx}-${dailyPlace.spotId}`}
                   bg={focus ? "gray.200" : "gray.100"}
                   p={2}
                   justify={onDelete ? "space-between" : "center"}
@@ -66,7 +66,7 @@ export const Daily = (props: DailyProps) => {
                       variant="ghost"
                       mr="3"
                       color={focus ? "gray.500" : "gray.400"}
-                      onClick={() => onDelete(_idx)}
+                      onClick={() => onDelete(dailyPlaceIdx)}
                     />
                   )}
                 </HStack>

--- a/src/features/schedules/components/Daily/Daily.tsx
+++ b/src/features/schedules/components/Daily/Daily.tsx
@@ -1,4 +1,13 @@
-import { Box, Heading, Stack, Text } from "@chakra-ui/react";
+/* eslint-disable array-callback-return */
+import {
+  Box,
+  Heading,
+  Stack,
+  Text,
+  IconButton,
+  HStack,
+} from "@chakra-ui/react";
+import { IoClose } from "react-icons/io5";
 
 type DailyPlace = {
   date: number;
@@ -8,28 +17,27 @@ type DailyPlace = {
 
 type DailyProps = {
   idx: number;
-  focus: boolean;
-  onClick: (idx: number) => void;
   dailyPlaces: DailyPlace[];
+  focus?: boolean;
+  onClick?: (idx: number) => void;
   className?: string;
+  onDelete?: (idx: number) => void;
+  setSelectedPlaceIdx?: (idx: number) => void;
 };
 
-export const Daily = ({
-  idx,
-  focus,
-  onClick,
-  dailyPlaces,
-  className,
-}: DailyProps) => {
+export const Daily = (props: DailyProps) => {
+  const { idx, focus, onClick, dailyPlaces, className, onDelete } = props;
+
   return (
     <Box
       bg={focus ? "gray.100" : "gray.50"}
       minW="108"
       minH="160"
       py={4}
+      pb={8}
       borderRadius="md"
       onClick={() => {
-        onClick(idx);
+        onClick && onClick(idx);
       }}
       className={className}
     >
@@ -38,22 +46,33 @@ export const Daily = ({
           day{idx + 1}
         </Heading>
         <Stack spacing={2}>
-          {dailyPlaces
-            .filter((dailyPlace) => dailyPlace.date === idx)
-            .map((dailyPlace, _idx) => {
+          {dailyPlaces.map((dailyPlace, _idx, array) => {
+            if (dailyPlace.date === idx) {
               return (
-                <Box
+                <HStack
                   key={`Daily-${_idx}-${dailyPlace.spotId}`}
                   bg={focus ? "gray.200" : "gray.100"}
                   p={2}
-                  textAlign="center"
+                  justify={onDelete ? "space-between" : "center"}
                 >
                   <Text fontSize="sm" color={focus ? "gray.900" : "gray.500"}>
                     {dailyPlace.placeName}
                   </Text>
-                </Box>
+                  {onDelete && (
+                    <IconButton
+                      aria-label="delete-place"
+                      size="xs"
+                      icon={<IoClose />}
+                      variant="ghost"
+                      mr="3"
+                      color={focus ? "gray.500" : "gray.400"}
+                      onClick={() => onDelete(_idx)}
+                    />
+                  )}
+                </HStack>
               );
-            })}
+            }
+          })}
         </Stack>
       </Stack>
     </Box>

--- a/src/features/schedules/components/Dailys/Dailys.tsx
+++ b/src/features/schedules/components/Dailys/Dailys.tsx
@@ -4,19 +4,23 @@ import { Daily } from "../Daily";
 
 type DailysProps = {
   totalDays: number;
-  selectedDateIdx: number;
-  setSelectedDateIdx: any;
   dailyPlaces: any;
+  selectedDateIdx?: number;
+  setSelectedDateIdx?: any;
   className?: string;
+  onDelete?: (idx: number) => void;
 };
 
-export const Dailys = ({
-  totalDays,
-  selectedDateIdx,
-  setSelectedDateIdx,
-  dailyPlaces,
-  className,
-}: DailysProps) => {
+export const Dailys = (props: DailysProps) => {
+  const {
+    totalDays,
+    selectedDateIdx,
+    setSelectedDateIdx,
+    dailyPlaces,
+    className,
+    onDelete,
+  } = props;
+
   return (
     <>
       {Array.from({ length: totalDays }, (_, idx) => idx).map((idx) => (
@@ -27,6 +31,7 @@ export const Dailys = ({
           dailyPlaces={dailyPlaces}
           onClick={setSelectedDateIdx}
           className={className}
+          onDelete={onDelete}
         />
       ))}
     </>

--- a/src/pages/schedules/SchedulesPage.tsx
+++ b/src/pages/schedules/SchedulesPage.tsx
@@ -4,6 +4,30 @@ import { Link } from "react-router-dom";
 import { PrivatePageLayout } from "@/components/Layout";
 import { Schedules } from "@/features/schedules/components/Schedules";
 
+const dummy = [
+  {
+    id: 1,
+    title: "string",
+    startDate: [2021, 12, 13],
+    endDate: [2021, 12, 13],
+    thema: ["FOOD"],
+  },
+  {
+    id: 2,
+    title: "string",
+    startDate: [2021, 12, 13],
+    endDate: [2021, 12, 13],
+    thema: ["FOOD"],
+  },
+  {
+    id: 3,
+    title: "string",
+    startDate: [2021, 12, 13],
+    endDate: [2021, 12, 13],
+    thema: ["FOOD"],
+  },
+];
+
 export const SchedulesPage = () => {
   return (
     <PrivatePageLayout

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,6 @@
+import { differenceInDays, isEqual } from "date-fns";
+
+export const getTotalDays = (endDate: Date, startDate: Date) => {
+  const correction = !isEqual(endDate, startDate) ? 2 : 1;
+  return differenceInDays(endDate, startDate) + correction;
+};


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- AddScheduleForm 상태 값들이 **react-hook-form** 교체 되었습니다.
- yup을 이용한 validtaion이 추가되었습니다.
- form 속성 중 복잡한 형태의 dailySchedulePlaces는 [**useFieldArray**](https://codesandbox.io/s/react-hook-form-usefieldarray-forked-9k15l?file=/src/index.js:375-381)를 사용해 관리했습니다.
- Carousel 컴포넌트가 children이나 props 변화를 감지하여 **동적으로 캐러셀의 기능을 유지**하는 코드를 추가하였습니다. 
- theme이 checkbox에서 **radiobox**로 교체되었습니다. 
   - `Unable to preventDefault...` 오류 해결 : text를 Radio컴포넌트의 children으로 주지 않고, 외부 label을 추가하여 병렬적으로 감싸는 방법
- 내부 장소 글자가 잘보이도록 Carousel의 **perView**를 조절하였습니다.

## 추후 추가되어야 할 사항 
- 현재 Daily 컴포넌트에서 모든 장소가 삭제 기능이 구현되어있는데, 마지막 장소만 delete 되는 기능으로의 리팩토링은 시간관계상 추후에 진행하도록 하겠습니다.😿

## 📸 스크린샷

schedule 페이지-day1            | 
:-------------------------:
![image](https://user-images.githubusercontent.com/80511900/146135878-d960e33f-7c01-4d75-9bdf-41fe4540d5b7.png)
![image](https://user-images.githubusercontent.com/80511900/146136068-c680864e-db0f-493f-84b0-c50d4ad54028.png)

