### PR TITLE
fix: div상위 p태그

### DIFF
--- a/src/features/schedules/components/ScheduleDetail/ScheduleDetail.tsx
+++ b/src/features/schedules/components/ScheduleDetail/ScheduleDetail.tsx
@@ -76,11 +76,8 @@ export const ScheduleDetail = ({ scheduleId }: ScheduleDetailProps) => {
       </Flex>
 
       <Flex justify="space-between" align="center">
-        <Text fontSize="lg">
-          <ThemeTag
-            theme={formattedSchedule.scheduleSimpleResponse.themes[0]}
-          />
-        </Text>
+        <ThemeTag theme={formattedSchedule.scheduleSimpleResponse.themes[0]} />
+
         <Text fontSize="md" color="gray.500">
           {formattedSchedule.scheduleSimpleResponse.startDate} ~{" "}
           {formattedSchedule.scheduleSimpleResponse.endDate}

--- a/src/features/schedules/components/ScheduleDetail/ScheduleDetail.tsx
+++ b/src/features/schedules/components/ScheduleDetail/ScheduleDetail.tsx
@@ -61,7 +61,7 @@ export const ScheduleDetail = ({ scheduleId }: ScheduleDetailProps) => {
     new Date(schedule.scheduleSimpleResponse.endDate),
     new Date(schedule.scheduleSimpleResponse.startDate)
   );
-  console.log(schedule);
+
   return (
     <Stack spacing={4}>
       <Flex justify="space-between" align="center">


### PR DESCRIPTION
## 🧑‍💻 PR 내용

ScheduleDetail 컴포넌트 내` <div> `상위` <p>` 태그로 인해 ` validateDOMnesting(...): <div> cannot appear as a descendant of <p> `오류 발생 
- 해당되는 p 태그를 삭제하였습니다

## 📸 스크린샷

스크린샷을 첨부해주세요.
