### PR TITLE
fix: spotOrder 1부터 시작

### DIFF
--- a/src/features/schedules/components/AddSchleduleForm/AddScheduleForm.tsx
+++ b/src/features/schedules/components/AddSchleduleForm/AddScheduleForm.tsx
@@ -269,9 +269,10 @@ export const AddScheduleForm = () => {
                 append({
                   ...selectedPlace,
                   dateOrder: selectedDateIdx + 1,
-                  order: fields.filter(
-                    (dailyPlace: any) => dailyPlace.date === selectedDateIdx
-                  ).length,
+                  order:
+                    fields.filter(
+                      (dailyPlace: any) => dailyPlace.date === selectedDateIdx
+                    ).length + 1,
                 });
               }}
             />


### PR DESCRIPTION
## 🧑‍💻 PR 내용

0부터 시작하는 일정(Schedule)생성 데이터의 spotOrder, placeOrder 1부터 시작으로 변경합니다

## 📸 스크린샷

스크린샷을 첨부해주세요.
