### PR TITLE
feat: 메모 및 투표 페이지 유저 정보와 액션버튼 조건부 렌더

### DIFF
--- a/src/features/memo/components/MemoHeader/MemoHeader.tsx
+++ b/src/features/memo/components/MemoHeader/MemoHeader.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { ActionsMenu } from "@/components/ActionsMenu";
 import { User } from "@/components/User";
 import { useMemoData, useDeleteMemo } from "@/features/memo/hooks";
+import { useMyProfileData } from "@/features/user/hooks";
 
 type MemoHeaderProps = {
   memoId?: string;
@@ -21,6 +22,8 @@ export const MemoHeader = ({ memoId, scheduleId }: MemoHeaderProps) => {
   });
 
   const { memberSimpleResponse } = data;
+
+  const { data: myprofile } = useMyProfileData();
 
   const { mutateAsync: deleteMemo } = useDeleteMemo();
 
@@ -38,15 +41,17 @@ export const MemoHeader = ({ memoId, scheduleId }: MemoHeaderProps) => {
       <Flex height="100px" alignItems="center">
         <User size="md" nickname={memberSimpleResponse?.nickname} />
         <Spacer />
-        <ActionsMenu icon={<IoEllipsisHorizontalSharp />}>
-          <Box onClick={() => onDelete()} color="red">
-            삭제
-          </Box>
-          <Box as={Link} to={`/memo/update/${memoId}`} state={scheduleId}>
-            수정
-          </Box>
-          <Box color="gray.500">취소</Box>
-        </ActionsMenu>
+        {myprofile.id === memberSimpleResponse.id ? (
+          <ActionsMenu icon={<IoEllipsisHorizontalSharp />}>
+            <Box onClick={() => onDelete()} color="red">
+              삭제
+            </Box>
+            <Box as={Link} to={`/memo/update/${memoId}`} state={scheduleId}>
+              수정
+            </Box>
+            <Box color="gray.500">취소</Box>
+          </ActionsMenu>
+        ) : null}
       </Flex>
     </Box>
   );

--- a/src/features/memo/components/MemoHeader/MemoHeader.tsx
+++ b/src/features/memo/components/MemoHeader/MemoHeader.tsx
@@ -19,10 +19,10 @@ export const MemoHeader = ({ memoId, scheduleId }: MemoHeaderProps) => {
   const { data } = useMemoData({
     memoId: Number(memoId),
     scheduleId: Number(scheduleId),
+    enabled: !!memoId,
   });
 
   const { memberSimpleResponse } = data;
-
   const { data: myprofile } = useMyProfileData();
 
   const { mutateAsync: deleteMemo } = useDeleteMemo();
@@ -41,7 +41,7 @@ export const MemoHeader = ({ memoId, scheduleId }: MemoHeaderProps) => {
       <Flex height="100px" alignItems="center">
         <User size="md" nickname={memberSimpleResponse?.nickname} />
         <Spacer />
-        {myprofile.id === memberSimpleResponse.id ? (
+        {myprofile?.id === memberSimpleResponse?.id ? (
           <ActionsMenu icon={<IoEllipsisHorizontalSharp />}>
             <Box onClick={() => onDelete()} color="red">
               삭제

--- a/src/features/note/components/MemoList/MemoList.tsx
+++ b/src/features/note/components/MemoList/MemoList.tsx
@@ -60,9 +60,8 @@ export const MemoList = ({ scheduleId: id }: MemoListProps) => {
                 isReadOnly
                 resize="none"
                 variant="unstyled"
-              >
-                {memo.content}
-              </Textarea>
+                value={memo.content}
+              />
             </Box>
           </ChakraLink>
         ))}

--- a/src/features/vote/components/VoteHeader/VoteHeader.tsx
+++ b/src/features/vote/components/VoteHeader/VoteHeader.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 import { ActionsMenu } from "@/components/ActionsMenu";
 import { User } from "@/components/User";
+import { useMyProfileData } from "@/features/user/hooks";
 import { useVoteData, useDeleteVote } from "@/features/vote/hooks";
 
 type VoteHeaderProps = {
@@ -17,6 +18,8 @@ export const VoteHeader = ({ voteId, scheduleId }: VoteHeaderProps) => {
     scheduleId: Number(scheduleId),
     votingId: Number(voteId),
   });
+
+  const { data: myprofile } = useMyProfileData();
 
   const { mutateAsync: deleteVote } = useDeleteVote();
 
@@ -36,12 +39,14 @@ export const VoteHeader = ({ voteId, scheduleId }: VoteHeaderProps) => {
       <Flex height="100px" alignItems="center">
         <User size="md" nickname={memberSimpleResponse?.nickname} />
         <Spacer />
-        <ActionsMenu icon={<IoEllipsisHorizontalSharp />}>
-          <Box onClick={() => onDelete()} color="red">
-            삭제
-          </Box>
-          <Box color="gray.500">취소</Box>
-        </ActionsMenu>
+        {myprofile?.id === memberSimpleResponse?.id ? (
+          <ActionsMenu icon={<IoEllipsisHorizontalSharp />}>
+            <Box onClick={() => onDelete()} color="red">
+              삭제
+            </Box>
+            <Box color="gray.500">취소</Box>
+          </ActionsMenu>
+        ) : null}
       </Flex>
     </Box>
   );

--- a/src/pages/memo/MemoPage.tsx
+++ b/src/pages/memo/MemoPage.tsx
@@ -5,16 +5,10 @@ import { useParams, useLocation } from "react-router-dom";
 import { GoToBackButton } from "@/components/GoToBackButton";
 import { PrivatePageLayout } from "@/components/Layout";
 import { MemoHeader, MemoContent } from "@/features/memo/components";
-// import { useMemoData } from "@/features/memo/hooks";
 
 export const MemoPage = () => {
   const { memoId } = useParams();
   const { state: scheduleId } = useLocation();
-
-  // const { data } = useMemoData({
-  //   memoId: Number(memoId),
-  //   scheduleId: Number(scheduleId),
-  // });
 
   return (
     <PrivatePageLayout

--- a/src/pages/memo/MemoUpdatePage.tsx
+++ b/src/pages/memo/MemoUpdatePage.tsx
@@ -6,9 +6,12 @@ import { GoToBackButton } from "@/components/GoToBackButton";
 import { PrivatePageLayout } from "@/components/Layout";
 import { User } from "@/components/User";
 import { MemoUpdateForm } from "@/features/memo/components";
+import { useMyProfileData } from "@/features/user/hooks";
 
 export const MemoUpdatePage = () => {
   const { memoId } = useParams();
+
+  const { data: myprofile } = useMyProfileData();
 
   return (
     <PrivatePageLayout
@@ -21,7 +24,7 @@ export const MemoUpdatePage = () => {
       }
     >
       <Flex h={100}>
-        <User size="md" />
+        <User size="md" nickname={myprofile.nickname} />
       </Flex>
       <MemoUpdateForm />
     </PrivatePageLayout>

--- a/src/pages/vote/VoteUpdatePage.tsx
+++ b/src/pages/vote/VoteUpdatePage.tsx
@@ -4,9 +4,12 @@ import React from "react";
 import { GoToBackButton } from "@/components/GoToBackButton";
 import { PrivatePageLayout } from "@/components/Layout";
 import { User } from "@/components/User";
+import { useMyProfileData } from "@/features/user/hooks";
 import { VoteUpdateForm } from "@/features/vote/components";
 
 export const VoteUpdatePage = () => {
+  const { data: myprofile } = useMyProfileData();
+
   return (
     <PrivatePageLayout
       title="id"
@@ -18,7 +21,7 @@ export const VoteUpdatePage = () => {
       }
     >
       <Flex h={100}>
-        <User size="md" />
+        <User size="md" nickname={myprofile.nickname} />
       </Flex>
       <VoteUpdateForm />
     </PrivatePageLayout>


### PR DESCRIPTION
## 🧑‍💻 PR 내용

`useMyProfile` 훅으로 현재 접속 유저의 정보를 조회합니다.

해당 페이지의 작성자 정보를 표시하고, 현재 접속한 유저와 작성자가 일치할 경우 액션버튼을 렌더합니다.

