### PR TITLE
fix: 일정(schedule) react-query checklistId key 추가

### DIFF
--- a/src/features/schedules/components/Checklist/Checklist.tsx
+++ b/src/features/schedules/components/Checklist/Checklist.tsx
@@ -49,9 +49,9 @@ export const Checklist = (props: ChecklistProps) => {
           <List ml="1" color="gray.500">
             <CheckboxGroup colorScheme="cyan">
               {isLoading && (
-                <Stack my="1" spacing={2}>
-                  <Skeleton height="20px" />
-                  <Skeleton height="20px" />
+                <Stack my="3" spacing={1}>
+                  <Skeleton height="18px" />
+                  <Skeleton height="18px" />
                 </Stack>
               )}
               {checklists

--- a/src/features/schedules/hooks/useChecklistData.ts
+++ b/src/features/schedules/hooks/useChecklistData.ts
@@ -19,7 +19,7 @@ export const getChecklists = ({
 export type UseChecklistsDataProps = GetChecklistsDTO;
 
 export const useChecklistsData = ({ scheduleId }: UseChecklistsDataProps) => {
-  const { data = [], ...rest } = useQuery(["checklists"], () =>
+  const { data = [], ...rest } = useQuery(["checklists", scheduleId], () =>
     getChecklists({ scheduleId })
   );
   return { data, ...rest };


### PR DESCRIPTION
## 🧑‍💻 PR 내용

일정(Schedule) 체크리스트 GET 시 react-query에서 scheduleId key가 누락되어 이전 schedule 체크리스트가 보이는 이슈
-> 체크리스트 GET 시 scheduleId key 추가

## 📸 스크린샷

스크린샷을 첨부해주세요.
