### PR TITLE
fix: 일정(schedule) 하루 당 최대 spot 제한 추가

### DIFF
--- a/src/features/schedules/components/AddSchleduleForm/AddScheduleForm.tsx
+++ b/src/features/schedules/components/AddSchleduleForm/AddScheduleForm.tsx
@@ -101,6 +101,7 @@ const schema = yup.object().shape({
         placeName: yup.string(),
         roadAddressName: yup.string(),
         spotId: yup.string(),
+        spotOrder: yup.number().min(1).max(6),
       })
     )
     .min(1, "최소 하나의 여행 장소를 추가해 주세요"),
@@ -264,6 +265,13 @@ export const AddScheduleForm = () => {
             <RoundAddButton
               onClick={() => {
                 if (!selectedPlace) return;
+                if (
+                  fields.filter(
+                    (dailyPlace: DailyPlace) =>
+                      dailyPlace.dateOrder === selectedDateIdx + 1
+                  ).length > 5
+                )
+                  return;
                 append({
                   ...selectedPlace,
                   dateOrder: selectedDateIdx + 1,


### PR DESCRIPTION
## 🧑‍💻 PR 내용

- 현재 6개 이상 추가 시 POST 에러가 발생하여, 일정(schedule) 생성 시 하루 당 최대 spot을 6개로 제한합니다.
- 따로 ui info는 없으나, 6개 이상 form 추가가 되지 않게 제한하였습니다.

