### PR TITLE
fix: GoToBack 컴포넌트에 특정 페이지로 갈 수 있는 props 추가

### DIFF
--- a/src/components/GoToBackButton/GoToBackButton.tsx
+++ b/src/components/GoToBackButton/GoToBackButton.tsx
@@ -1,13 +1,26 @@
 import { Button } from "@chakra-ui/react";
+import React from "react";
 import { IoChevronBack } from "react-icons/io5";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 
-export const GoToBackButton = () => {
+type GoToBackButtonProps = {
+  target?: string;
+};
+
+export const GoToBackButton = ({ target }: GoToBackButtonProps) => {
   const navigate = useNavigate();
 
   return (
-    <Button onClick={() => navigate(-1)} variant="unstyled">
-      <IoChevronBack size={30} />
-    </Button>
+    <>
+      {target ? (
+        <Button as={Link} to={target} variant="unstyled">
+          <IoChevronBack size={30} />
+        </Button>
+      ) : (
+        <Button onClick={() => navigate(-1)} variant="unstyled">
+          <IoChevronBack size={30} />
+        </Button>
+      )}
+    </>
   );
 };

--- a/src/pages/note/NotePage.tsx
+++ b/src/pages/note/NotePage.tsx
@@ -6,12 +6,11 @@ import {
   TabPanels,
   TabPanel,
   Box,
-  Button,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
-import { IoChevronBack } from "react-icons/io5";
-import { useLocation, Link } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
+import { GoToBackButton } from "@/components/GoToBackButton";
 import { GoToUpdateButton } from "@/components/GoToUpdateButton";
 import { PrivatePageLayout } from "@/components/Layout";
 import { MemoList, VoteList } from "@/features/note/components";
@@ -27,9 +26,7 @@ export const NotePage = () => {
       title="메모 및 투표"
       header={
         <>
-          <Button as={Link} to={`/schedules/${scheduleId}`} variant="unstyled">
-            <IoChevronBack size={30} />
-          </Button>
+          <GoToBackButton target={`/schedules/${scheduleId}`} />
           <Heading size="lg">메모 및 투표</Heading>
         </>
       }

--- a/src/pages/schedules/SchedulePage.tsx
+++ b/src/pages/schedules/SchedulePage.tsx
@@ -25,7 +25,7 @@ export const SchedulePage = () => {
         title="id"
         header={
           <>
-            <GoToBackButton />
+            <GoToBackButton target={"/schedules"} />
             <Heading size="lg">스케줄 보기</Heading>
           </>
         }


### PR DESCRIPTION
## 🧑‍💻 PR 내용

노트 페이지와 일정디테일페이지에서 이전 방문지와 상관없이 특정 경로로 돌아갈 수 있도록 GoToBackButton 에 target 옵션 prop 추가

